### PR TITLE
Release v1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=68", "wheel" ]
 
 [project]
 name = "repo-review-automation"
-version = "1.0.1"
+version = "1.0.2"
 description = "Central reusable GitHub Actions workflow for weekly repository review reports."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/repo_review_automation/__init__.py
+++ b/repo_review_automation/__init__.py
@@ -1,4 +1,4 @@
 """Repository review automation package metadata."""
 
 __all__ = ["__version__"]
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -4,4 +4,4 @@ from repo_review_automation import __version__
 
 
 def test_package_version_matches_release_bump() -> None:
-    assert __version__ == "1.0.1"
+    assert __version__ == "1.0.2"


### PR DESCRIPTION
## Summary
- bump the package and release workflow version from `1.0.1` to `1.0.2`
- update the package metadata test to match the new release version

## Validation
- `pytest -q`