### PR TITLE
Use append publish mode for refresh comments

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       tool_ref: v4
       execution_mode: refresh
-      publish_mode: update_latest_scoped
+      publish_mode: append
       publish_all_clear_comments_in_refresh: false
       target_patch_coverage: "100"
       include_review_comments: true


### PR DESCRIPTION
## Summary
- change the refresh workflow to use `publish_mode: append`
- keep the rest of the refresh behavior unchanged

## Why
The current refresh workflow uses `update_latest_scoped`, which updates the latest refresh-scoped managed comment in place. Switching to `append` makes each refresh-triggered run publish a new PR comment instead.

## Validation
- workflow file change only
