### PR TITLE
Document minimum OpenAI API key permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,7 @@ For a restricted OpenAI API key, the minimum required permission set is:
 
 - `Chat completions (/v1/chat/completions)`: `Request`
 
-Everything else can remain:
-
-- `None`
+All other OpenAI API key permissions can remain set to `None` (disabled).
 
 You do not need `Responses`, `Assistants`, `Threads`, `Files`, `Embeddings`, `Moderations`, or media-related permissions for the current workflow.
 


### PR DESCRIPTION
## Summary
- document the minimum OpenAI API key permissions required for the current workflow
- clarify that the current implementation uses `/v1/chat/completions` and only needs `Chat completions: Request`
- note that all other OpenAI key permissions can remain disabled and how this would change if the workflow later moves to the Responses API

## Scope
- README-only documentation update
- no workflow or code changes
