### PR TITLE
Fix self-review workflow invocation

### DIFF
--- a/.github/workflows/weekly-repo-review.yml
+++ b/.github/workflows/weekly-repo-review.yml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   weekly-review:
-    environment: repo-review
     uses: ./.github/workflows/repo-review.yml
     with:
       create_issues: true


### PR DESCRIPTION
## Summary
- remove the unsupported `environment` key from the self-hosting caller workflow job
- keep the local reusable-workflow reference and explicit `OPENAI_API_KEY` secret mapping
- make manual dispatch and scheduled runs queue successfully again

## Context
GitHub does not allow `environment:` on a job that invokes a reusable workflow with job-level `uses:`. With that key present, the workflow parser falls back to normal-job validation and rejects `uses`, `with`, and `secrets`.

## Validation
- YAML parse validation for `.github/workflows/weekly-repo-review.yml`
