### PR TITLE
Fix reusable workflow parse error

### DIFF
--- a/.github/workflows/repo-review.yml
+++ b/.github/workflows/repo-review.yml
@@ -348,7 +348,6 @@ jobs:
 
       - name: Render summary comment artifact
         if: ${{ !inputs.create_issues }}
-        env:
         shell: bash
         run: |
           python automation/scripts/post_summary_comment.py \


### PR DESCRIPTION
## Summary
- remove the empty `env:` key from the report-only summary comment step in the reusable workflow
- fix the GitHub Actions parser error that blocks manual dispatch of the self-hosting workflow

## Context
The reusable workflow currently contains an empty mapping key:

```yaml
- name: Render summary comment artifact
  if: ${{ !inputs.create_issues }}
  env:
  shell: bash
```

GitHub parses that as an unexpected empty value and rejects callers of the reusable workflow.

## Validation
- YAML parse validation for `.github/workflows/repo-review.yml`
