### PR TITLE
Surface OpenAI API error details

### DIFF
--- a/scripts/run_ai_review.py
+++ b/scripts/run_ai_review.py
@@ -112,15 +112,16 @@ def format_openai_error(response: requests.Response) -> str:
     except ValueError:
         return response.text.strip() or "<empty response body>"
 
-    error = payload.get("error")
-    if isinstance(error, dict):
-        parts = []
-        for key in ("message", "type", "code", "param"):
-            value = error.get(key)
-            if value is not None:
-                parts.append(f"{key}={value}")
-        if parts:
-            return ", ".join(parts)
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            parts = []
+            for key in ("message", "type", "code", "param"):
+                value = error.get(key)
+                if value is not None:
+                    parts.append(f"{key}={value}")
+            if parts:
+                return ", ".join(parts)
 
     return json.dumps(payload, sort_keys=True)
 


### PR DESCRIPTION
## Summary
- parse OpenAI error bodies before raising on non-2xx responses
- keep the existing 401 hint, but append the API's own error details
- include structured error details for 400s and other request failures

## Why
The workflow currently collapses OpenAI failures into a bare `requests.exceptions.HTTPError`, which hides the actual API error message. This makes it impossible to tell whether a 400 is caused by payload size, schema validation, unsupported response format, or something else.

## Validation
- `python -m py_compile scripts/run_ai_review.py`
- `ruff check scripts/run_ai_review.py`
