### PR TITLE
Fix OpenAI response schema required fields

### DIFF
--- a/scripts/run_ai_review.py
+++ b/scripts/run_ai_review.py
@@ -60,6 +60,7 @@ def build_schema() -> dict[str, Any]:
                             "summary",
                             "evidence",
                             "recommended_fix",
+                            "proposed_issue_body",
                         ],
                         "properties": {
                             "title": {"type": "string", "minLength": 5},


### PR DESCRIPTION
## Summary
- add `proposed_issue_body` to the OpenAI response schema's required fields
- align the `required` array with the declared `properties`
- fix the current workflow failure from OpenAI schema validation

## Why
The schema sent in `response_format` declared `proposed_issue_body` in `properties` but omitted it from the object's `required` list. OpenAI rejects that schema with:

`Missing 'proposed_issue_body'`

This PR makes the schema internally consistent and should unblock the AI review step.

## Validation
- `python -m py_compile scripts/run_ai_review.py`
- `ruff check scripts/run_ai_review.py`
