### PR TITLE
Fix artifact download paths in follow-up jobs

### DIFF
--- a/.github/workflows/repo-review.yml
+++ b/.github/workflows/repo-review.yml
@@ -514,14 +514,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: repo-review-report
-          path: .
+          path: out
 
       - name: Download review findings fallback
         if: ${{ !inputs.upload_artifacts }}
         uses: actions/download-artifact@v4
         with:
           name: _review-findings-passthrough
-          path: .
+          path: out
 
       - name: Initialize missing report-only artifacts when needed
         if: ${{ !inputs.upload_artifacts }}
@@ -678,14 +678,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: _review-findings-passthrough
-          path: .
+          path: out
 
       - name: Download review artifacts for update
         if: ${{ inputs.upload_artifacts }}
         uses: actions/download-artifact@v4
         with:
           name: repo-review-report
-          path: .
+          path: out
 
       - name: Materialize effective config
         id: config


### PR DESCRIPTION
## Summary
- download review artifacts into `out/` in the `post_report_comment` and `create_issues` jobs
- preserve the expected `out/...` paths after artifact extraction
- fix the missing `out/effective_config.json` failure in follow-up jobs

## Why
The report artifact is uploaded from files under `out/`, so the artifact root becomes the contents of `out` rather than the repository root. The downstream jobs were downloading into `.` and then trying to read `out/effective_config.json`, which does not exist in that layout.

Downloading into `out/` restores the path shape the later steps expect.

## Validation
- `python - <<'PY' ... yaml.safe_load(...)`
